### PR TITLE
Accept tunnel-prefixed MCP paths

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -12,6 +12,7 @@ const COMMAND_TIMEOUT = 30_000;
 const RUN_COMMAND_LOOP_SUPPRESSION_MS = 60_000;
 const PERMISSION_MODE = normalizePermissionMode(process.env.POKE_GATE_PERMISSION_MODE);
 const SANDBOX_EXEC_PATH = "/usr/bin/sandbox-exec";
+const TUNNEL_MCP_PATH_RE = /^\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/mcp$/;
 
 let logEnabled = false;
 
@@ -222,6 +223,11 @@ function extractSessionId(req) {
     return sessionId.trim();
   }
   return "default";
+}
+
+export function normalizeMcpPathname(pathname) {
+  if (pathname === "/mcp" || TUNNEL_MCP_PATH_RE.test(pathname)) return "/mcp";
+  return pathname;
 }
 
 function buildApprovalResponse(name, cleanArgs, approval) {
@@ -879,8 +885,9 @@ export function startMcpServer(port = 0) {
       }
 
       const url = new URL(req.url, "http://localhost");
+      const pathname = normalizeMcpPathname(url.pathname);
 
-      if (url.pathname === "/mcp" && req.method === "GET") {
+      if (pathname === "/mcp" && req.method === "GET") {
         const accept = req.headers.accept || "";
         if (accept.includes("text/event-stream")) {
           writeMcpEventStream(req, res);
@@ -891,7 +898,7 @@ export function startMcpServer(port = 0) {
         return;
       }
 
-      if (url.pathname === "/mcp" && req.method === "POST") {
+      if (pathname === "/mcp" && req.method === "POST") {
         try {
           const body = await readBody(req);
           const parsed = JSON.parse(body);

--- a/test/mcp-server-transport.test.js
+++ b/test/mcp-server-transport.test.js
@@ -4,6 +4,8 @@ import test from "node:test";
 
 import { startMcpServer } from "../src/mcp-server.js";
 
+const TUNNEL_CONNECTION_ID = "64574786-7a08-4074-ab67-8078a40b7ba2";
+
 function request({ port, method = "GET", path = "/", headers = {}, body }) {
   return new Promise((resolve, reject) => {
     const req = http.request({ hostname: "127.0.0.1", port, method, path, headers }, (res) => {
@@ -64,6 +66,66 @@ test("MCP GET supports event stream transport", async () => {
     assert.equal(res.headers["content-type"], "text/event-stream");
     assert.equal(res.headers["mcp-session-id"], "session-2");
     assert.match(body, /: connected/);
+  } finally {
+    httpServer.close();
+  }
+});
+
+test("MCP POST accepts Poke tunnel connection-id prefix", async () => {
+  const { httpServer, port } = await startMcpServer();
+  try {
+    const { res, body } = await request({
+      port,
+      method: "POST",
+      path: `/${TUNNEL_CONNECTION_ID}/mcp`,
+      headers: {
+        "Content-Type": "application/json",
+        "Mcp-Session-Id": "session-prefixed-post",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["mcp-session-id"], "session-prefixed-post");
+    assert.equal(JSON.parse(body).result.tools.length > 0, true);
+  } finally {
+    httpServer.close();
+  }
+});
+
+test("MCP GET accepts Poke tunnel connection-id prefix", async () => {
+  const { httpServer, port } = await startMcpServer();
+  try {
+    const { res, body } = await request({
+      port,
+      path: `/${TUNNEL_CONNECTION_ID}/mcp`,
+      headers: {
+        Accept: "text/event-stream",
+        "Mcp-Session-Id": "session-prefixed-get",
+      },
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["content-type"], "text/event-stream");
+    assert.equal(res.headers["mcp-session-id"], "session-prefixed-get");
+    assert.match(body, /: connected/);
+  } finally {
+    httpServer.close();
+  }
+});
+
+test("MCP route rejects non-connection-id prefixes", async () => {
+  const { httpServer, port } = await startMcpServer();
+  try {
+    const { res } = await request({
+      port,
+      method: "POST",
+      path: "/not-a-connection/mcp",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+
+    assert.equal(res.statusCode, 404);
   } finally {
     httpServer.close();
   }


### PR DESCRIPTION
## Summary
- normalize Poke tunnel requests from `/<connection-id>/mcp` to `/mcp` before routing
- keep the compatibility path narrow to UUID-shaped connection IDs
- add regression coverage for prefixed MCP POST, prefixed SSE GET, and non-connection prefixes

## Root Cause
Poke can proxy tool calls to the local gateway with the tunnel connection ID still in the request path, for example `/<connection-id>/mcp`. The local MCP server only accepted exact `/mcp`, so the tunnel could appear connected while real tool calls returned 404 locally.

## Validation
- `npm test`
- `npm run lint`

Related to #18.