### PR TITLE
fix: accept tunnel-prefixed MCP paths (/<id>/mcp)

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -879,8 +879,9 @@ export function startMcpServer(port = 0) {
       }
 
       const url = new URL(req.url, "http://localhost");
+      const isMcpPath = url.pathname === "/mcp" || /^\/[0-9a-f-]+\/mcp$/i.test(url.pathname);
 
-      if (url.pathname === "/mcp" && req.method === "GET") {
+      if (isMcpPath && req.method === "GET") {
         const accept = req.headers.accept || "";
         if (accept.includes("text/event-stream")) {
           writeMcpEventStream(req, res);
@@ -891,7 +892,7 @@ export function startMcpServer(port = 0) {
         return;
       }
 
-      if (url.pathname === "/mcp" && req.method === "POST") {
+      if (isMcpPath && req.method === "POST") {
         try {
           const body = await readBody(req);
           const parsed = JSON.parse(body);


### PR DESCRIPTION
## Problem

The Poke cloud routes tool calls through the tunnel using paths like `/<tunnel-id>/mcp` instead of just `/mcp`. The MCP server only matched the exact path `/mcp`, so every proxied request returned a **404 Not Found**, causing Poke to report "no available upstreams" / "upstream error".

## Root Cause

The tunnel's data plane proxies HTTP requests from the cloud to the local MCP server using the path as sent by the cloud. The cloud uses the tunnel ID as a routing prefix (e.g., `POST /<uuid>/mcp`), but `startMcpServer()` only checked for `url.pathname === "/mcp"`.

The initial tunnel activation probe uses plain `/mcp` (so discovery succeeds), but subsequent tool calls use the prefixed path.

## Fix

Added an `isMcpPath` check that accepts both:
- `/mcp` — the canonical path
- `/<uuid>/mcp` — the tunnel-prefixed path used by the cloud (UUID format: `8-4-4-4-12` hex)

## Testing

All 22 existing tests pass. Manually verified with Poke cloud — tunnel activation probes `/mcp` and tool calls at `/<tunnel-id>/mcp` both resolve correctly.